### PR TITLE
v0.2.9: balance tuning pass — reduce early-game harshness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,23 @@ Requires Node ≥ 18.
 - localStorage for saves (single save slot, key `isle-of-elden-save-v8` as of v0.2.8 — bump on breaking state-shape changes)
 - **No engine, no UI framework.** If UI complexity demands it, React can layer in — don't reach for Phaser/Pixi/Godot.
 
+## Current mechanics (v0.2.9)
+
+### Balance tuning (v0.2.9)
+
+Early-game harshness reduced without touching the core farming break-even model.
+
+| Constant | Before | After | File |
+|---|---|---|---|
+| Starting food | 20 | 30 | `state.ts:newGame()` |
+| Starting wood | 10 | 18 | `state.ts:newGame()` |
+| Starting stone | 0 | 5 | `state.ts:newGame()` |
+| `LIFESPAN_RANGE` | [8, 12] | [10, 15] | `types.ts` |
+| Locusts damage | -8 food | -6 food | `events.ts` |
+| Forest fire damage | -8 wood | -6 wood | `events.ts` |
+
+**What was not changed:** farmer yield (2), `FOOD_PER_ADULT` (2), growth threshold (pop × 3). The farming break-even design — one farmer sustains one adult on baseline grass, surplus requires fertile tiles — is preserved. No SAVE_KEY bump needed (state shape unchanged).
+
 ## Current mechanics (v0.2.8)
 
 ### Buildings (v0.2.8)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ The world is low-fantasy: classical creatures exist but magic is fading, and the
 
 ## Status
 
-**v0.2.8 — Buildings.** Three one-time settlement upgrades give negative events a counter: a **granary** blocks locusts, a **palisade** blocks bandits, a **well** blocks wildfires. Buying them drains food/wood/stone, giving your surplus somewhere to go and a reason to keep woodcutters and quarrymen in rotation.
+**v0.2.9 — Balance tuning.** Early game is less punishing: starting food/wood/stone bumped, pops live longer (lifespan [10–15] up from [8–12]), and locust/wildfire events deal -6 instead of -8. The farming break-even model (1 farmer = 1 adult fed) is unchanged.
+
+### In v0.2.9
+- Starting resources: food 20→30, wood 10→18, stone 0→5
+- `LIFESPAN_RANGE` [8, 12] → [10, 15] — more productive years per pop, less constant turnover
+- Locusts and wildfire events: -8 → -6 (still painful, no longer immediately ruinous early game)
+
+### In v0.2.8 — Buildings. Three one-time settlement upgrades give negative events a counter: a **granary** blocks locusts, a **palisade** blocks bandits, a **well** blocks wildfires. Buying them drains food/wood/stone, giving your surplus somewhere to go and a reason to keep woodcutters and quarrymen in rotation.
 
 ### In v0.2.8
 - **Buildings sidebar.** New section under Villagers listing each upgrade with its cost and a Build button. Built ones show checked, with a green border.

--- a/src/events.ts
+++ b/src/events.ts
@@ -42,7 +42,7 @@ const EVENTS: EventDef[] = [
     blockedBy: "granary",
     blockedText: "Locusts descend on the fields, but the granary stores hold firm. (Averted)",
     apply: (s) => {
-      const lost = Math.min(8, s.food);
+      const lost = Math.min(6, s.food);
       s.food -= lost;
       return {
         year: s.year,
@@ -122,7 +122,7 @@ const EVENTS: EventDef[] = [
     blockedBy: "well",
     blockedText: "A blaze threatens the timber yards, but bucket crews from the well douse it before it spreads. (Averted)",
     apply: (s) => {
-      const lost = Math.min(8, s.wood);
+      const lost = Math.min(6, s.wood);
       s.wood -= lost;
       return {
         year: s.year,

--- a/src/state.ts
+++ b/src/state.ts
@@ -70,9 +70,9 @@ export function newGame(): GameState {
   const state: GameState = {
     year: 1,
     pops: starterPops,
-    food: 20,
-    wood: 10,
-    stone: 0,
+    food: 30,
+    wood: 18,
+    stone: 5,
     gold: 5,
     tiles,
     town,

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,7 @@ export const MAP_H = 15;
 export const TILE_SIZE = 32;
 
 export const ADULT_AGE = 4;
-export const LIFESPAN_RANGE: [number, number] = [8, 12];
+export const LIFESPAN_RANGE: [number, number] = [10, 15];
 // Starter pops are a spread of adult ages so they don't all die in the same year.
 export const STARTER_AGE_RANGE: [number, number] = [4, 7];
 // Newcomer events arrive as fresh adults partway through life.


### PR DESCRIPTION
Starting food 20→30, wood 10→18, stone 0→5; LIFESPAN_RANGE [8,12]→[10,15]
so pops have more productive years; locust and wildfire event damage -8→-6.
Farming break-even model (1 farmer = 1 adult fed) is unchanged.

https://claude.ai/code/session_01C8Ctbvsc8SaTRvpCMsGWxo